### PR TITLE
Make redox test not depend on compiler vendor

### DIFF
--- a/configure
+++ b/configure
@@ -3869,7 +3869,7 @@ case "${target}" in
   vax-*-*)
     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
     ;;
-  *-elf-redox)
+  *-*-redox)
     noconfigdirs="$noconfigdirs readline gdb"
     ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1203,7 +1203,7 @@ case "${target}" in
   vax-*-*)
     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
     ;;
-  *-elf-redox)
+  *-*-redox)
     noconfigdirs="$noconfigdirs readline gdb"
     ;;
 esac


### PR DESCRIPTION
See https://github.com/redox-os/libc/pull/37.